### PR TITLE
App link support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 Mygod
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Other features:
 
 ## Guide for custom build
 
-1. Put your domain inside `reactmap.defaultDomain` of `gradle.properties`.
-2. If you want to support more domains, edit `app/src/main/AndroidManifest.xml`: find the line `<data android:host="@string/default_domain" />` and add more domains by adding lines like `<data android:host="www.reactmap.dev" />`.
+1. Customize `reactmap.defaultDomain` and `reactmap.packageName` in `gradle.properties`.
+2. If you want to support more domains, edit `app/src/main/AndroidManifest.xml`: find the line `<data android:host="${defaultDomain}" />` and add more domains by adding lines like `<data android:host="www.reactmap.dev" />`.
 3. Build.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ Other features:
 * More conveniently refresh the webpage when fullscreen. (During network congestion, Chrome HTTP/3 scheduler retries requests at its own pace. Doing a manual refresh overrides this.)
 * Login button is clicked automatically (Discord login only).
 * You could make alerts follow location in background.
+
+## Guide for custom build
+
+1. Put your domain inside `default_domain` of `app/src/main/res/values/strings.xml`.
+2. Build.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,45 @@ Other features:
 
 ## Guide for custom build
 
-1. Customize `reactmap.defaultDomain` and `reactmap.packageName` in `gradle.properties`.
-2. If you want to support more domains, edit `app/src/main/AndroidManifest.xml`: find the line `<data android:host="${defaultDomain}" />` and add more domains by adding lines like `<data android:host="www.reactmap.dev" />`.
-3. Build.
+### Setup instructions
+
+1. If you have not already, generate a signing key with [`keytool`](https://developer.android.com/build/building-cmdline#sign_cmdline).
+   Using [RSA with a key length of 4096, 8192, or 16384 bits](https://github.com/google/bundletool/blob/0b9149c283e2df73850da670f2130a732639283d/src/main/java/com/android/tools/build/bundletool/commands/AddTransparencyCommand.java#L97) is recommended.
+2. Create the following file at `https://mymap.com/.well-known/assetlinks.json` by creating the file in `/path/to/reactmap/public/.well-known/assetlinks.json`:
+   ```json
+   [
+     {
+       "relation": [
+         "delegate_permission/common.handle_all_urls"
+       ],
+       "target": {
+         "namespace": "android_app",
+         "package_name": "be.mygod.reactmap.com.mymap",
+         "sha256_cert_fingerprints": [
+           "insert your sha256 cert fingerprint"
+         ]
+       }
+     }
+   ]
+   ```
+   where the fingerprint can be obtained via `keytool -list -v -keystore /path/to/keystore`.
+   (If you prefer to using Android Studio to create this file with a wizard, see [here]( https://developer.android.com/studio/write/app-link-indexing#associatesite) for instructions.)
+3. (Optional) Make modifications to the source code if you wish.
+
+### Build instructions
+
+Build with [injected properties](https://stackoverflow.com/a/47356720/2245107) (modifying these values as you wish):
+```
+./gradlew assembleRelease \
+ -Pandroid.injected.signing.store.file=$KEYFILE \
+ -Pandroid.injected.signing.store.password=$STORE_PASSWORD \
+ -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+ -Pandroid.injected.signing.key.password=$KEY_PASSWORD \
+ -Preactmap.defaultHost=mymap.com \
+ -Preactmap.packageName=be.mygod.reactmap.com.mymap
+```
+
+Optionally you can also inject `reactmap.appName`.
+An alternative to using `-P` switches is to adding your properties to the `gradle.properties` file in the root directory.
+
+Success! Find your apk in `app/build/outputs/apk/release`.

--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ Other features:
 ## Guide for custom build
 
 1. Put your domain inside `default_domain` of `app/src/main/res/values/strings.xml`.
-2. Build.
+2. If you want to support more domains, edit `app/src/main/AndroidManifest.xml`: find the line `<data android:host="@string/default_domain" />` and add more domains by adding lines like `<data android:host="www.reactmap.dev" />`.
+3. Build.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Other features:
 
 ## Guide for custom build
 
-1. Put your domain inside `default_domain` of `app/src/main/res/values/strings.xml`.
+1. Put your domain inside `reactmap.defaultDomain` of `gradle.properties`.
 2. If you want to support more domains, edit `app/src/main/AndroidManifest.xml`: find the line `<data android:host="@string/default_domain" />` and add more domains by adding lines like `<data android:host="www.reactmap.dev" />`.
 3. Build.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,7 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+        if (extra.has("reactmap.appName")) resValue("string", "app_name", extra["reactmap.appName"] as String)
         extra["reactmap.defaultDomain"]!!.let { defaultDomain ->
             manifestPlaceholders["defaultDomain"] = defaultDomain
             buildConfigField("String", "DEFAULT_DOMAIN", "\"$defaultDomain\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,11 +1,12 @@
+import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
+
 plugins {
     alias(libs.plugins.androidApplication)
+    // https://developers.google.com/android/guides/google-services-plugin#processing_the_json_file
+//    alias(libs.plugins.googleServices)
     alias(libs.plugins.firebaseCrashlytics)
     alias(libs.plugins.kotlinAndroid)
     id("kotlin-parcelize")
-
-    // https://developers.google.com/android/guides/google-services-plugin#processing_the_json_file
-//    alias(libs.plugins.googleServices)
 }
 
 android {
@@ -34,6 +35,9 @@ android {
         release {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            if (!pluginManager.hasPlugin("com.google.gms.google-services")) {
+                the<CrashlyticsExtension>().mappingFileUploadEnabled = false
+            }
         }
     }
     buildFeatures.buildConfig = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.firebaseCrashlytics)
-    alias(libs.plugins.googleServices)
+//    alias(libs.plugins.googleServices)
     alias(libs.plugins.kotlinAndroid)
     id("kotlin-parcelize")
 }
@@ -11,7 +11,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "be.mygod.reactmap"
+        applicationId = extra["reactmap.packageName"] as String?
         minSdk = 26
         targetSdk = 34
         versionCode = 60

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.firebaseCrashlytics)
-//    alias(libs.plugins.googleServices)
     alias(libs.plugins.kotlinAndroid)
     id("kotlin-parcelize")
+
+    // https://developers.google.com/android/guides/google-services-plugin#processing_the_json_file
+//    alias(libs.plugins.googleServices)
 }
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,11 @@ android {
         versionName = "0.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        extra["reactmap.defaultDomain"]!!.let { defaultDomain ->
+            manifestPlaceholders["defaultDomain"] = defaultDomain
+            buildConfigField("String", "DEFAULT_DOMAIN", "\"$defaultDomain\"")
+        }
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,9 +2,9 @@ import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 
 plugins {
     alias(libs.plugins.androidApplication)
+    alias(libs.plugins.firebaseCrashlytics)
     // https://developers.google.com/android/guides/google-services-plugin#processing_the_json_file
 //    alias(libs.plugins.googleServices)
-    alias(libs.plugins.firebaseCrashlytics)
     alias(libs.plugins.kotlinAndroid)
     id("kotlin-parcelize")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "be.mygod.reactmap"
         minSdk = 26
         targetSdk = 34
-        versionCode = 53
-        versionName = "0.5.2"
+        versionCode = 60
+        versionName = "0.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,12 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <queries>
         <package android:name="com.nianticlabs.pokemongo" />
@@ -38,12 +38,12 @@
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
-
                 <data android:host="${defaultDomain}" />
             </intent-filter>
         </activity>
@@ -53,7 +53,7 @@
             android:enabled="false"
             android:exported="false">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
@@ -62,55 +62,57 @@
         <service
             android:name="androidx.work.impl.background.systemalarm.SystemAlarmService"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <service
             android:name="androidx.work.impl.background.systemjob.SystemJobService"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <service
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:directBootAware="true"
             android:foregroundServiceType="dataSync"
             tools:replace="android:directBootAware"
-            tools:node="merge"/>
+            tools:node="merge" />
+
         <receiver
             android:name="androidx.work.impl.utils.ForceStopRunnable$BroadcastReceiver"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <receiver
             android:name="androidx.work.impl.background.systemalarm.ConstraintProxy$BatteryChargingProxy"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <receiver
             android:name="androidx.work.impl.background.systemalarm.ConstraintProxy$BatteryNotLowProxy"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <receiver
             android:name="androidx.work.impl.background.systemalarm.ConstraintProxy$StorageNotLowProxy"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <receiver
             android:name="androidx.work.impl.background.systemalarm.ConstraintProxy$NetworkStateProxy"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <receiver
             android:name="androidx.work.impl.background.systemalarm.RescheduleReceiver"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <receiver
             android:name="androidx.work.impl.background.systemalarm.ConstraintProxyUpdateReceiver"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
         <receiver
             android:name="androidx.work.impl.diagnostics.DiagnosticsReceiver"
             android:directBootAware="true"
-            tools:replace="android:directBootAware"/>
+            tools:replace="android:directBootAware" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
-            tools:node="remove"/>
+            tools:node="remove" />
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"
-            tools:node="remove"/>
+            tools:node="remove" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
 
-                <data android:host="@string/default_domain" />
+                <data android:host="${defaultDomain}" />
             </intent-filter>
         </activity>
         <receiver

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,16 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+
+                <data android:host="@string/default_domain" />
+            </intent-filter>
         </activity>
         <receiver
             android:name=".follower.BackgroundLocationReceiver"

--- a/app/src/main/java/be/mygod/reactmap/App.kt
+++ b/app/src/main/java/be/mygod/reactmap/App.kt
@@ -43,7 +43,7 @@ class App : Application() {
     val nm by lazy { getSystemService<NotificationManager>()!! }
     val userManager by lazy { getSystemService<UserManager>()!! }
 
-    val activeUrl get() = pref.getString(KEY_ACTIVE_URL, null) ?: ("https://" + getString(R.string.default_domain))
+    val activeUrl get() = pref.getString(KEY_ACTIVE_URL, null) ?: "https://${BuildConfig.DEFAULT_DOMAIN}"
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/be/mygod/reactmap/App.kt
+++ b/app/src/main/java/be/mygod/reactmap/App.kt
@@ -78,13 +78,17 @@ class App : Application() {
             NotificationChannel(SiteController.CHANNEL_ID, "Full screen site controls",
                 NotificationManager.IMPORTANCE_LOW).apply {
                 lockscreenVisibility = Notification.VISIBILITY_SECRET
+                setShowBadge(false)
             },
             NotificationChannel(LocationSetter.CHANNEL_ID, "Background location updating",
                 NotificationManager.IMPORTANCE_LOW).apply {
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                setShowBadge(false)
             },
             NotificationChannel(LocationSetter.CHANNEL_ID_SUCCESS, "Background location updated",
-                NotificationManager.IMPORTANCE_MIN),
+                NotificationManager.IMPORTANCE_MIN).apply {
+                setShowBadge(false)
+            },
             NotificationChannel(LocationSetter.CHANNEL_ID_ERROR, "Background location update failed",
                 NotificationManager.IMPORTANCE_HIGH).apply {
                 enableLights(true)

--- a/app/src/main/java/be/mygod/reactmap/App.kt
+++ b/app/src/main/java/be/mygod/reactmap/App.kt
@@ -32,7 +32,6 @@ class App : Application() {
     companion object {
         private const val PREF_NAME = "reactmap"
         const val KEY_ACTIVE_URL = "url.active"
-        const val URL_DEFAULT = "https://www.reactmap.dev"
 
         lateinit var app: App
     }
@@ -44,7 +43,7 @@ class App : Application() {
     val nm by lazy { getSystemService<NotificationManager>()!! }
     val userManager by lazy { getSystemService<UserManager>()!! }
 
-    val activeUrl get() = pref.getString(KEY_ACTIVE_URL, URL_DEFAULT) ?: URL_DEFAULT
+    val activeUrl get() = pref.getString(KEY_ACTIVE_URL, null) ?: ("https://" + getString(R.string.default_domain))
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/be/mygod/reactmap/ConfigDialogFragment.kt
+++ b/app/src/main/java/be/mygod/reactmap/ConfigDialogFragment.kt
@@ -47,7 +47,8 @@ class ConfigDialogFragment : AlertDialogFragment<ConfigDialogFragment.Arg, Empty
     }
 
     override fun AlertDialog.Builder.prepare(listener: DialogInterface.OnClickListener) {
-        historyUrl = app.pref.getStringSet(KEY_HISTORY_URL, null) ?: setOf(App.URL_DEFAULT)
+        historyUrl = app.pref.getStringSet(KEY_HISTORY_URL, null) ?: setOf(
+            "https://" + getString(R.string.default_domain))
         val context = requireContext()
         urlEdit = AutoCompleteTextView(context).apply {
             isFocusedByDefault = true

--- a/app/src/main/java/be/mygod/reactmap/ConfigDialogFragment.kt
+++ b/app/src/main/java/be/mygod/reactmap/ConfigDialogFragment.kt
@@ -47,8 +47,7 @@ class ConfigDialogFragment : AlertDialogFragment<ConfigDialogFragment.Arg, Empty
     }
 
     override fun AlertDialog.Builder.prepare(listener: DialogInterface.OnClickListener) {
-        historyUrl = app.pref.getStringSet(KEY_HISTORY_URL, null) ?: setOf(
-            "https://" + getString(R.string.default_domain))
+        historyUrl = app.pref.getStringSet(KEY_HISTORY_URL, null) ?: setOf("https://${BuildConfig.DEFAULT_DOMAIN}")
         val context = requireContext()
         urlEdit = AutoCompleteTextView(context).apply {
             isFocusedByDefault = true

--- a/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
+++ b/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
@@ -268,7 +268,7 @@ class ReactMapFragment @JvmOverloads constructor(private val overrideUri: Uri? =
     }
 
     fun handleUri(uri: Uri?) = uri?.host?.let { host ->
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             withCreated { }
             if (host != hostname) {
                 hostname = host

--- a/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
+++ b/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
@@ -47,7 +47,7 @@ import java.net.URLDecoder
 import java.nio.charset.Charset
 import java.util.Locale
 
-class ReactMapFragment(private val overrideUri: Uri?) : Fragment() {
+class ReactMapFragment @JvmOverloads constructor(private val overrideUri: Uri? = null) : Fragment() {
     companion object {
         private val filenameExtractor = "filename=(\"([^\"]+)\"|[^;]+)".toRegex(RegexOption.IGNORE_CASE)
         private val vendorJsMatcher = "/vendor-[0-9a-f]{8}\\.js".toRegex()

--- a/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
+++ b/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
@@ -270,6 +270,7 @@ class ReactMapFragment @JvmOverloads constructor(private val overrideUri: Uri? =
     fun handleUri(uri: Uri?) = uri?.host?.let { host ->
         viewLifecycleOwner.lifecycleScope.launch {
             withCreated { }
+            Timber.d("Handling URI $uri")
             if (host != hostname) {
                 hostname = host
                 return@launch web.loadUrl(uri.toString())

--- a/app/src/main/java/be/mygod/reactmap/webkit/SiteController.kt
+++ b/app/src/main/java/be/mygod/reactmap/webkit/SiteController.kt
@@ -27,7 +27,7 @@ class SiteController(private val fragment: Fragment) : DefaultLifecycleObserver 
         app.nm.notify(1, Notification.Builder(context, CHANNEL_ID).apply {
             setWhen(0)
             setCategory(Notification.CATEGORY_SERVICE)
-            setContentTitle(title)
+            setContentTitle(title ?: "Loading…")
             setContentText("Tap to configure")
             setColor(context.getColor(R.color.main_blue))
             setGroup(CHANNEL_ID)
@@ -52,11 +52,7 @@ class SiteController(private val fragment: Fragment) : DefaultLifecycleObserver 
             }
         }
 
-    override fun onStart(owner: LifecycleOwner) {
-        if (title != null) requestPermission.launch(android.Manifest.permission.POST_NOTIFICATIONS)
-    }
-
-    override fun onStop(owner: LifecycleOwner) {
-        app.nm.cancel(1)
-    }
+    override fun onStart(owner: LifecycleOwner) =
+        requestPermission.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+    override fun onStop(owner: LifecycleOwner) = app.nm.cancel(1)
 }

--- a/app/src/main/res/values/google-services.xml
+++ b/app/src/main/res/values/google-services.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="default_web_client_id" translatable="false">53628743953-u05270s2od1es37b9pdrvmn10q6aa3iu.apps.googleusercontent.com</string>
+    <string name="gcm_defaultSenderId" translatable="false">53628743953</string>
+    <string name="google_api_key" translatable="false">AIzaSyDlBEXzi1_Kf0kY6cdxexhHfuxyrxx5ZB0</string>
+    <string name="google_app_id" translatable="false">1:53628743953:android:ef886035becf4f5adb1cb0</string>
+    <string name="google_crash_reporting_api_key" translatable="false">AIzaSyDlBEXzi1_Kf0kY6cdxexhHfuxyrxx5ZB0</string>
+    <string name="google_storage_bucket" translatable="false">reactmap-android.appspot.com</string>
+    <string name="project_id" translatable="false">reactmap-android</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
     <string name="app_name">ReactMap</string>
-    <string name="default_domain" translatable="false">www.reactmap.dev</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">ReactMap</string>
+    <string name="default_domain" translatable="false">www.reactmap.dev</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ android.enableVcsInfo=true
 
 # ReactMap settings for customized build
 reactmap.defaultDomain=www.reactmap.dev
+reactmap.packageName=be.mygod.reactmap

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,6 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.enableResourceOptimizations=false
 android.enableVcsInfo=true
+
+# ReactMap settings for customized build
+reactmap.defaultDomain=www.reactmap.dev

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity = "1.8.0-rc01"
-agp = "8.3.0-alpha05"
+agp = "8.3.0-alpha06"
 androidx-test-ext-junit = "1.1.5"
 browser = "1.6.0"
 core = "1.12.0"


### PR DESCRIPTION
Now you can click on a map link to have the map fly there without opening a new window! (Who would want that?) See the instructions in README to enable this for domains other than `www.reactmap.dev`.

Deep linking support requires ReactMap support, see also: https://developer.android.com/training/app-links/deep-linking
Otherwise this feature requires manual setup in app info on Android 12 or higher.

![image](https://github.com/Mygod/reactmap-android/assets/3511321/04c31420-9981-4040-ad6b-6143c5b6f4a0)
