### PR TITLE
Enlarge media cache size to 512MB

### DIFF
--- a/app/src/main/java/be/mygod/reactmap/util/UnblockCentral.kt
+++ b/app/src/main/java/be/mygod/reactmap/util/UnblockCentral.kt
@@ -3,12 +3,11 @@ package be.mygod.reactmap.util
 import android.annotation.SuppressLint
 import android.os.Build
 import android.system.Os
-import android.webkit.WebResourceResponse
 import androidx.annotation.RequiresApi
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import java.io.FileDescriptor
 
-@SuppressLint("BlockedPrivateApi", "DiscouragedPrivateApi", "SoonBlockedPrivateApi")
+@SuppressLint("BlockedPrivateApi", "DiscouragedPrivateApi")
 object UnblockCentral {
     /**
      * Retrieve this property before doing dangerous shit.
@@ -36,7 +35,4 @@ object UnblockCentral {
         Os::class.java.getDeclaredMethod("setsockoptLinger", FileDescriptor::class.java, Int::class.java,
             Int::class.java, classStructLinger)
     }
-
-    val mStatusCode by lazy { init.let { WebResourceResponse::class.java.getDeclaredField("mStatusCode") } }
-    val mReasonPhrase by lazy { init.let { WebResourceResponse::class.java.getDeclaredField("mReasonPhrase") } }
 }

--- a/app/src/main/java/be/mygod/reactmap/util/UnblockCentral.kt
+++ b/app/src/main/java/be/mygod/reactmap/util/UnblockCentral.kt
@@ -3,11 +3,12 @@ package be.mygod.reactmap.util
 import android.annotation.SuppressLint
 import android.os.Build
 import android.system.Os
+import android.webkit.WebResourceResponse
 import androidx.annotation.RequiresApi
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import java.io.FileDescriptor
 
-@SuppressLint("BlockedPrivateApi", "DiscouragedPrivateApi")
+@SuppressLint("BlockedPrivateApi", "DiscouragedPrivateApi", "SoonBlockedPrivateApi")
 object UnblockCentral {
     /**
      * Retrieve this property before doing dangerous shit.
@@ -35,4 +36,7 @@ object UnblockCentral {
         Os::class.java.getDeclaredMethod("setsockoptLinger", FileDescriptor::class.java, Int::class.java,
             Int::class.java, classStructLinger)
     }
+
+    val mStatusCode by lazy { init.let { WebResourceResponse::class.java.getDeclaredField("mStatusCode") } }
+    val mReasonPhrase by lazy { init.let { WebResourceResponse::class.java.getDeclaredField("mReasonPhrase") } }
 }

--- a/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
+++ b/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
@@ -32,6 +32,7 @@ import be.mygod.reactmap.MainActivity
 import be.mygod.reactmap.R
 import be.mygod.reactmap.follower.BackgroundLocationReceiver
 import be.mygod.reactmap.util.CreateDynamicDocument
+import be.mygod.reactmap.util.UnblockCentral
 import be.mygod.reactmap.util.findErrorStream
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -248,9 +249,17 @@ class ReactMapFragment : Fragment() {
         val charset = if (conn.contentEncoding == null) Charsets.UTF_8 else {
             Charset.forName(conn.contentEncoding)
         }
-        return WebResourceResponse(conn.contentType?.substringBefore(';'), conn.contentEncoding, conn.responseCode,
-            conn.responseMessage.let { if (it.isNullOrBlank()) "N/A" else it },
-            conn.headerFields.mapValues { (_, value) -> value.joinToString() }, data(charset))
+        return WebResourceResponse(conn.contentType?.substringBefore(';'), conn.contentEncoding, data(charset)).apply {
+            responseHeaders = conn.headerFields.mapValues { (_, value) -> value.joinToString() }
+            try {
+                UnblockCentral.mStatusCode.set(this, conn.responseCode)
+                UnblockCentral.mReasonPhrase.set(this, conn.responseMessage)
+            } catch (e: ReflectiveOperationException) {
+                Timber.w(e)
+                setStatusCodeAndReasonPhrase(conn.responseCode,
+                    conn.responseMessage.let { if (it.isNullOrBlank()) "N/A" else it })
+            }
+        }
     }
     private fun buildResponse(request: WebResourceRequest, transform: (Reader) -> String) = try {
         val url = request.url.toString()

--- a/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
+++ b/app/src/main/java/be/mygod/reactmap/webkit/ReactMapFragment.kt
@@ -148,9 +148,7 @@ class ReactMapFragment : Fragment() {
                     }
                 }
 
-                private var isOffMain = false
                 override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
-                    isOffMain = Uri.parse(url).host != hostname
                     glocation.clear()
                     if (url.toUri().host == hostname) glocation.setupGeolocation()
                 }
@@ -178,9 +176,13 @@ class ReactMapFragment : Fragment() {
                     }
                 }
 
-                private val mediaExtensions = setOf("apng", "png", "avif", "gif", "jpg", "jpeg", "jfif", "pjpeg", "pjp", "png", "svg", "webp", "bmp", "ico", "cur", "wav")
+                private val mediaExtensions = setOf(
+                    "apng", "png", "avif", "gif", "jpg", "jpeg", "jfif", "pjpeg", "pjp", "png", "svg", "webp", "bmp", "ico", "cur",
+                    "wav", "mp3", "mp4", "aac", "ogg", "flac",
+                    "css", "js",
+                    "ttf", "otf", "woff", "woff2",
+                )
                 override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest): WebResourceResponse? {
-                    if (request.isForMainFrame || isOffMain) return null
                     val path = request.url.path ?: return null
                     if (ReactMapHttpEngine.isCronet && path.substringAfterLast('.')
                             .lowercase(Locale.ENGLISH) in mediaExtensions) return try {

--- a/app/src/main/java/be/mygod/reactmap/webkit/ReactMapHttpEngine.kt
+++ b/app/src/main/java/be/mygod/reactmap/webkit/ReactMapHttpEngine.kt
@@ -31,7 +31,7 @@ object ReactMapHttpEngine {
         HttpEngine.Builder(app.deviceStorage).apply {
             if (cache.mkdirs() || cache.isDirectory) {
                 setStoragePath(cache.absolutePath)
-                setEnableHttpCache(HttpEngine.Builder.HTTP_CACHE_DISK, 256 * 1024 * 1024)
+                setEnableHttpCache(HttpEngine.Builder.HTTP_CACHE_DISK, 512 * 1024 * 1024)
             }
             setConnectionMigrationOptions(ConnectionMigrationOptions.Builder().apply {
                 setDefaultNetworkMigration(ConnectionMigrationOptions.MIGRATION_OPTION_ENABLED)


### PR DESCRIPTION
Android by default only seems to have a cache size of 20MB which leads to a lot of wasted bandwidth when using ReactMap daily. This aims to use Cronet library to intercept and cache media requests so that we can maintain control over the cache size. This is only supported on Android 14+ or 12-13 with the latest Google Play system update.